### PR TITLE
Use discord embeds for personalities output

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Once the server is started, simply send a message containing the personality nam
 * `/enable`: Enables the bot.
 * `/disable`: Disables the bot.
 * `/reset [all,<personality_name>]`: Resets the memory of all personalities or a single personality.
-* `/personalities`: List personalities.
+* `/personalities`: Lists available personalities and their prompts.
 
 ## Contributing
 Feel free to fork this repo and submit pull requests for different features, fixes, and changes.

--- a/commands/personalities.js
+++ b/commands/personalities.js
@@ -1,5 +1,5 @@
 // Requre the necessary discord.js classes
-const { SlashCommandBuilder, PermissionFlagsBits } = require('discord.js');
+const { SlashCommandBuilder, PermissionFlagsBits, EmbedBuilder } = require('discord.js');
 // Initialize .env file
 require('dotenv').config({ path: '/.env'});
 
@@ -15,14 +15,22 @@ module.exports = {
             await interaction.reply(process.env.DISABLED_MSG);
             return;
         }
-        // Create message variable
-		persMsg = process.env.PERSONALITY_MSG + "\n";
-		// Add personality names to variable
-		for (let i = 0; i < state.personalities.length; i++) {
-			let thisPersonality = state.personalities[i];
-			persMsg += "- " + thisPersonality.name + "\n"
-		}
+        // Create an embed object
+        let persEmbed = new EmbedBuilder()
+            .setColor(0x0099FF) // set the color of the embed
+            .setTitle(process.env.PERSONALITY_MSG) // set the title of the embed
+            .setDescription('Here are the personalities and their prompts'); // set the description of the embed
+        
+        // Add personality names and prompts to fields
+        for (let i = 0; i < state.personalities.length; i++) {
+            let thisPersonality = state.personalities[i];
+            // Find the prompt from the request array
+            let prompt = thisPersonality.request.find(item => item.role === 'system').content;
+            // Truncate the prompt to 1024 characters if it's longer than that
+            let truncatedPrompt = prompt.substring(0, 1024);
+            persEmbed.addFields({ name: thisPersonality.name, value: truncatedPrompt });
+        }
 		// Send variable
-		interaction.reply(persMsg);
+        interaction.reply({ embeds: [persEmbed] });
     },
 };


### PR DESCRIPTION
Imports EmbedBuilder from discord.js and uses it to create an embed for the output of `/personalities`. Each personality is then added to the embed as a field, with the name being the field name and the prompt being the field value. If the prompt is longer than 1024 characters, it is truncated.

A discord embed has a `Title` (larger top text) property and a `Description` (smaller bottom text). I went ahead and used the `PERSONALITY_MSG` env var for the title, but this can be changed, or another env var can be added for the description. Let me know what you'd prefer.

