### PR TITLE
add /add-personality command

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,8 +37,10 @@ Once the server is started, simply send a message containing the personality nam
 ### Commands
 * `/enable`: Enables the bot.
 * `/disable`: Disables the bot.
-* `/reset [all,<personality_name>]`: Resets the memory of all personalities or a single personality.
-* `/personalities`: List personalities.
+* `/reset [all,<personality_name>]`: Resets the memory of all personalities or a single personality. If personality is ephemeral, sets its prompt to `undefined`.
+* `/personalities`: Lists available personalities.
+* `/add-personality`: Adds an ephemeral personality to the bot, it will be lost when the bot restarts. Can also update `undefined` prompts.
+  - Usage: `/add-personality <name> <prompt>`
 
 ## Contributing
 Feel free to fork this repo and submit pull requests for different features, fixes, and changes.

--- a/commands/add.js
+++ b/commands/add.js
@@ -1,0 +1,56 @@
+// Requre the necessary discord.js classes
+const { SlashCommandBuilder, PermissionFlagsBits } = require('discord.js');
+// Initialize .env file
+require('dotenv').config({ path: '/.env'});
+
+module.exports = {
+    data: new SlashCommandBuilder()
+        .setName('add-personality')
+        .setDescription('Add a new personality to the bot.')
+        .addStringOption(option =>
+            option.setName('name')
+                .setDescription('The name of the new personality.')
+                .setRequired(true))
+        .addStringOption(option =>
+            option.setName('prompt')
+                .setDescription('The prompt for the new personality.')
+                .setRequired(true)),
+    async execute(interaction, state) {
+        // Commands to execute
+        // Check admin/pause state
+        if (!interaction.member.permissions.has(PermissionFlagsBits.ManageMessages) && state.isPaused === true) {
+            await interaction.reply(process.env.DISABLED_MSG);
+            return;
+        }
+        const name = interaction.options.getString('name');
+        const prompt = interaction.options.getString('prompt');
+
+        // Check if personality already exists
+        const existingPersonality = state.personalities.find(p => p.name.toUpperCase() === name.toUpperCase());
+        if (existingPersonality) {
+            // If the existing prompt is undefined and a new prompt is provided, update it
+            if (typeof existingPersonality.prompt === 'undefined' && prompt) {
+                existingPersonality.prompt = prompt;
+                existingPersonality.request = [{
+                    "role": "system",
+                    "content": `${prompt}`
+                }];
+                await interaction.reply(`Updated the prompt for the existing personality "${name}".`);
+            } else {
+                await interaction.reply('A personality with this name already exists. Please choose a different name.');
+            }
+            return;
+        }
+
+        // Add the new personality
+        state.personalities.push({
+            name: name,
+            request: [{
+                "role": "system",
+                "content": `${prompt}`
+            }]
+        });
+
+        await interaction.reply(`New personality "${name}" added.`);
+    },
+};


### PR DESCRIPTION
Adds command `/add-personality` which allows a user to add an ephemeral personality to the bot, it will be lost when the bot restarts. 

The use case for this is just to try new personalities with the bot before deciding to add them as permanent personalities via environment variables.

If /reset is used on the new personality, the prompt will be set to `undefined` (instead of the original prompt), and the personality will respond as if it had no prompt. The /add-personalities command can only update personalities with an `undefined` prompt, so there's no fear in overwriting personalities set in environment variables. 